### PR TITLE
ci: Remove paths-ignore from workflow trigger

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -9,11 +9,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR addresses no issue.

We have a [hanging action](https://github.com/user-attachments/assets/1c2fba92-3357-4bb5-bfbc-1252322fb9b6).

This is happening because we require `check-dist` to pass on incoming PRs. However, `check-dist` won't run if the PR only changes Markdown files... which is exactly what #1 does.

This PR proposes removing the `paths-ignore` option from the `push` and `pull_request` triggers for `check-dist`. Although we'll be running `check-dist` more than we really _need_ to, it'll allow us to keep `check-dist` as a required check (which is preferable).
